### PR TITLE
chore: convert true to always pull policy

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -16,7 +16,7 @@ Sample of restoring a cache:
 steps:
   - name: restore_cache
     image: target/vela-s3-cache:v0.1.0
-    pull: true
+    pull: always
     parameters:
       action: restore
       root: mybucket
@@ -29,7 +29,7 @@ Sample of rebuilding a cache:
 steps:
   - name: rebuild_cache
     image: target/vela-s3-cache:v0.1.0
-    pull: true
+    pull: always
     parameters:
       action: rebuild
       root: mybucket
@@ -44,7 +44,7 @@ Sample of flushing a cache:
 steps:
   - name: flushing_cache
     image: target/vela-s3-cache:v0.1.0
-    pull: true
+    pull: always
     parameters:
       action: flush
       root: mybucket
@@ -61,7 +61,7 @@ You can use Vela secrets to substitute sensitive values at runtime:
 steps:
   - name: restore_cache
     image: target/vela-s3-cache:v0.1.0
-    pull: true
+    pull: always
 +   secrets: [ cache_access_key, cache_secret_key ]
     parameters:
       action: restore

--- a/DOCS.md
+++ b/DOCS.md
@@ -8,14 +8,14 @@ Registry: https://hub.docker.com/r/target/vela-s3-cache
 
 ## Usage
 
-_The plugin supports reading all parameters via environment variables or files. Values set as a file take precedence over default values set from the environment._
+**NOTE: It is not recommended to use `latest` as the tag for the Docker image. Users should use a semantically versioned tag instead.**
 
 Sample of restoring a cache:
 
 ```yaml
 steps:
   - name: restore_cache
-    image: target/vela-s3-cache:v0.1.0
+    image: target/vela-s3-cache:latest
     pull: always
     parameters:
       action: restore
@@ -28,7 +28,7 @@ Sample of rebuilding a cache:
 ```yaml
 steps:
   - name: rebuild_cache
-    image: target/vela-s3-cache:v0.1.0
+    image: target/vela-s3-cache:latest
     pull: always
     parameters:
       action: rebuild
@@ -43,7 +43,7 @@ Sample of flushing a cache:
 ```yaml
 steps:
   - name: flushing_cache
-    image: target/vela-s3-cache:v0.1.0
+    image: target/vela-s3-cache:latest
     pull: always
     parameters:
       action: flush
@@ -60,7 +60,7 @@ You can use Vela secrets to substitute sensitive values at runtime:
 ```diff
 steps:
   - name: restore_cache
-    image: target/vela-s3-cache:v0.1.0
+    image: target/vela-s3-cache:latest
     pull: always
 +   secrets: [ cache_access_key, cache_secret_key ]
     parameters:
@@ -72,6 +72,11 @@ steps:
 ```
 
 ## Parameters
+
+**NOTE:**
+
+* the plugin supports reading all parameters via environment variables or files
+* values set from a file take precedence over values set from the environment
 
 The following parameters can used to configure all image actions:
 


### PR DESCRIPTION
This PR updates the existing docs for the `pull` attribute to match the newly created pull policies.

To accomplish this, I performed a find and replace for converting

```
pull: true
```

to

```
pull: always
```

Also found in this PR is updating the tag for the Docker image we reference to `latest` 👍 