### PR TITLE
fix: address upstream function deprecation

### DIFF
--- a/cmd/vela-s3-cache/config.go
+++ b/cmd/vela-s3-cache/config.go
@@ -4,7 +4,9 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
+	"time"
 
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
@@ -51,8 +53,17 @@ func (c *Config) New() (*minio.Client, error) {
 	} else {
 		creds = credentials.NewIAM("")
 
-		// See if the IAM role can be retrieved
-		_, err := creds.Get()
+		// creating http client to use for credential tset
+		httpClient := &http.Client{
+			Timeout: 15 * time.Second,
+		}
+
+		credContext := &credentials.CredContext{
+			Client: httpClient,
+		}
+
+		// attempt to retrieve the IAM role
+		_, err := creds.GetWithContext(credContext)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/vela-s3-cache/config.go
+++ b/cmd/vela-s3-cache/config.go
@@ -53,7 +53,7 @@ func (c *Config) New() (*minio.Client, error) {
 	} else {
 		creds = credentials.NewIAM("")
 
-		// creating http client to use for credential tset
+		// creating http client to use for IAM role request
 		httpClient := &http.Client{
 			Timeout: 15 * time.Second,
 		}


### PR DESCRIPTION
upstream change encouraged use of new function (GetWithContext) that allows to pass custom context. you can pass `nil` (which is what the current Get() did under the hood) and then it will just use default http client (without any timeout). so, i created a http client with a 15s timeout which seems generous to try and fetch an IAM role.