### PR TITLE
enhance: use better compression package

### DIFF
--- a/cmd/vela-s3-cache/main.go
+++ b/cmd/vela-s3-cache/main.go
@@ -3,12 +3,12 @@
 package main
 
 import (
-	"compress/flate"
 	"encoding/json"
 	"fmt"
 	"os"
 	"time"
 
+	"github.com/klauspost/compress/flate"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 

--- a/cmd/vela-s3-cache/rebuild.go
+++ b/cmd/vela-s3-cache/rebuild.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"compress/flate"
 	"context"
 	"fmt"
 	"os"
@@ -11,6 +10,7 @@ import (
 	"time"
 
 	"github.com/dustin/go-humanize"
+	"github.com/klauspost/compress/flate"
 	"github.com/minio/minio-go/v7"
 	"github.com/sirupsen/logrus"
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-vela/server v0.26.4
 	github.com/google/go-cmp v0.7.0
 	github.com/joho/godotenv v1.5.1
+	github.com/klauspost/compress v1.18.0
 	github.com/minio/minio-go/v7 v7.0.90
 	github.com/sirupsen/logrus v1.9.3
 	github.com/urfave/cli/v2 v2.27.6
@@ -18,7 +19,6 @@ require (
 	github.com/go-ini/ini v1.67.0 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.10 // indirect
 	github.com/minio/crc64nvme v1.0.1 // indirect
 	github.com/minio/md5-simd v1.1.2 // indirect

--- a/pkg/archiver/targzip.go
+++ b/pkg/archiver/targzip.go
@@ -4,13 +4,14 @@ package archiver
 
 import (
 	"archive/tar"
-	"compress/gzip"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+
+	"github.com/klauspost/compress/gzip"
 )
 
 // TarGzipArchiver is an Archiver that compresses and adds files to a tar archive.

--- a/pkg/archiver/targzip_test.go
+++ b/pkg/archiver/targzip_test.go
@@ -5,7 +5,6 @@ package archiver
 import (
 	"archive/tar"
 	"bytes"
-	"compress/gzip"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,6 +14,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/klauspost/compress/gzip"
 )
 
 func TestTarGzipArchiver(t *testing.T) {


### PR DESCRIPTION
dropping in the [klauspost lib](https://github.com/klauspost/compress) for better perf. in my testing over multiple runs about 6-7x faster at the default compression setting which i think aligns with their claims. it's generally faster and only starts falling behind on best compression setting. fwiw, the previous archiver package we used also used this lib.